### PR TITLE
Fix code scanning alert no. 16: Disabled Spring CSRF protection

### DIFF
--- a/storage-service/src/main/java/com/github/advancedsecurity/storageservice/WebSecurityConfig.java
+++ b/storage-service/src/main/java/com/github/advancedsecurity/storageservice/WebSecurityConfig.java
@@ -44,7 +44,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 		BearerAuthenticationFilter filter = new BearerAuthenticationFilter(authenticationManager(), this.antPattern);
 		filter.setAuthenticationSuccessHandler(jwtAuthenticationSuccessHandler);
 		http.cors().and()
-			 .csrf().disable()
+			 .csrf().and()
 			 .authorizeRequests().antMatchers(this.antPattern).authenticated().and()
 			 .addFilterBefore(filter, UsernamePasswordAuthenticationFilter.class)
 			 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);


### PR DESCRIPTION
Fixes [https://github.com/koderproxy/ghas-demo/security/code-scanning/16](https://github.com/koderproxy/ghas-demo/security/code-scanning/16)

To fix the problem, we need to enable CSRF protection in the `configure` method of the `WebSecurityConfig` class. This can be done by removing the `.csrf().disable()` line and allowing Spring Security to handle CSRF protection by default. This change ensures that the application is protected against CSRF attacks without altering its existing functionality.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
